### PR TITLE
pr@dev@fix_oidc_token_endpoint_auth_method

### DIFF
--- a/apps/authentication/backends/oidc/backends.py
+++ b/apps/authentication/backends/oidc/backends.py
@@ -103,9 +103,23 @@ class OIDCAuthCodeBackend(OIDCBaseBackend):
         # Prepares the token payload that will be used to request an authentication token to the
         # token endpoint of the OIDC provider.
         logger.debug(log_prompt.format('Prepares token payload'))
+
+        """ The reason for need not client_id and client_secret in token_payload.
+
+        OIDC protocol indicate client's token_endpoint_auth_method only accept one type in
+            - client_secret_basic
+            - client_secret_post
+            - client_secret_jwt
+            - private_key_jwt
+            - none
+        If the client offer more than one auth method type to OIDC, OIDC will auth client failed.
+        OIDC default use client_secret_basic, this type only need in headers add Authorization=Basic xxx.
+        More info see: https://github.com/jumpserver/jumpserver/issues/8165
+
+        """
         token_payload = {
-            'client_id': settings.AUTH_OPENID_CLIENT_ID,
-            'client_secret': settings.AUTH_OPENID_CLIENT_SECRET,
+            # 'client_id': settings.AUTH_OPENID_CLIENT_ID,
+            # 'client_secret': settings.AUTH_OPENID_CLIENT_SECRET,
             'grant_type': 'authorization_code',
             'code': code,
             'redirect_uri': build_absolute_uri(


### PR DESCRIPTION
#### What this PR does / why we need it?
Fix bug: oidc client token_endpoint_auth_method
https://github.com/jumpserver/jumpserver/issues/8165

#### Summary of your change
Remove client_id and client_secret in request OIDC token endpoint payload.

#### Please indicate you've done the following:

- [ ] Made sure tests are passing and test coverage is added if needed.
- [ ] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.